### PR TITLE
update: Update project recruiting list func

### DIFF
--- a/src/main/java/com/matching/project/config/SecurityConfig.java
+++ b/src/main/java/com/matching/project/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 //                         .hasRole("ADMIN")
 //                     .antMatchers("/*", "/v1/*", "/h2-console/*").permitAll();
                 .antMatchers("/v1/project").hasRole("USER")
+                .antMatchers("/v1/project/login/*").hasRole("USER")
                 .antMatchers("/*").permitAll()
                 //.anyRequest().authenticated();
 

--- a/src/main/java/com/matching/project/controller/ProjectController.java
+++ b/src/main/java/com/matching/project/controller/ProjectController.java
@@ -32,19 +32,27 @@ public class ProjectController {
     }
 
     @GetMapping("/recruitment")
-    @ApiOperation(value = "모집중인 프로젝트 목록 조회")
-    public ResponseEntity projectRecruitingList(@PageableDefault(size = 5, sort = "no", direction = Sort.Direction.DESC) Pageable pageable) throws Exception{
-        List<ProjectSimpleDto> projectSimpleDtoList = projectService.projectRecruitingList(pageable);
+    @ApiOperation(value = "비로그인 : 모집중인 프로젝트 목록 조회")
+    public ResponseEntity noneLoginProjectRecruitingList(@PageableDefault(size = 5, sort = "no", direction = Sort.Direction.DESC) Pageable pageable) throws Exception{
+        List<NoneLoginProjectSimpleDto> projectSimpleDtoList = projectService.NoneLoginProjectRecruitingList(pageable);
+        return ResponseEntity.ok(new ResponseDto<>(null, projectSimpleDtoList));
+    }
+
+    @GetMapping("/login/recruitment")
+    @ApiOperation(value = "로그인 : 모집중인 프로젝트 목록 조회")
+    public ResponseEntity LoginProjectRecruitingList(@PageableDefault(size = 5, sort = "no", direction = Sort.Direction.DESC) Pageable pageable) throws Exception{
+        List<LoginProjectSimpleDto> projectSimpleDtoList = projectService.LoginProjectRecruitingList(pageable);
         return ResponseEntity.ok(new ResponseDto<>(null, projectSimpleDtoList));
     }
 
     @GetMapping("/recruitment/complete")
-    @ApiOperation(value = "모집 완료된 프로젝트 목록 조회")
+    @ApiOperation(value = "비로그인 : 모집 완료된 프로젝트 목록 조회")
     public ResponseEntity projectRecruitingCompleteList() {
-        List<ProjectSimpleDto> projectDtoList = new ArrayList<>();
+        List<LoginProjectSimpleDto> projectDtoList = new ArrayList<>();
 
         return new ResponseEntity(projectDtoList, HttpStatus.OK);
     }
+
 
     @GetMapping("/{projectNo}")
     @ApiOperation(value = "프로젝트 상세 조회")
@@ -55,7 +63,7 @@ public class ProjectController {
     @PostMapping("/search")
     @ApiOperation(value = "프로젝트 검색")
     public ResponseEntity projectSearch(ProjectSearchRequestDto projectSearchRequestDto) {
-        List<ProjectSimpleDto> projectDtoList = new ArrayList<>();
+        List<NoneLoginProjectSimpleDto> projectDtoList = new ArrayList<>();
 
         return new ResponseEntity(projectDtoList, HttpStatus.OK);
     }

--- a/src/main/java/com/matching/project/dto/project/LoginProjectSimpleDto.java
+++ b/src/main/java/com/matching/project/dto/project/LoginProjectSimpleDto.java
@@ -3,19 +3,17 @@ package com.matching.project.dto.project;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Getter
 @Builder
-public class ProjectSimpleDto {
+public class LoginProjectSimpleDto {
     private Long no;
     private String name;
     private String profile;
-    private boolean bookmark;
     private Integer maxPeople;
     private Integer currentPeople;
     private Integer viewCount;
     private Integer commentCount;
     private String register;
+    private boolean bookMark;
 }
+

--- a/src/main/java/com/matching/project/dto/project/NoneLoginProjectSimpleDto.java
+++ b/src/main/java/com/matching/project/dto/project/NoneLoginProjectSimpleDto.java
@@ -1,0 +1,20 @@
+package com.matching.project.dto.project;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class NoneLoginProjectSimpleDto {
+    private Long no;
+    private String name;
+    private String profile;
+    private Integer maxPeople;
+    private Integer currentPeople;
+    private Integer viewCount;
+    private Integer commentCount;
+    private String register;
+}

--- a/src/main/java/com/matching/project/entity/Project.java
+++ b/src/main/java/com/matching/project/entity/Project.java
@@ -2,10 +2,7 @@ package com.matching.project.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.matching.project.dto.project.ProjectRegisterRequestDto;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
@@ -105,5 +102,25 @@ public class Project {
                 .commentCount(0)
                 .image(null)
                 .build();
+    }
+
+    @Override
+    public String toString() {
+        return "Project{" +
+                "no=" + no +
+                ", name='" + name + '\'' +
+                ", createUserName='" + createUserName + '\'' +
+                ", createDate=" + createDate +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                ", state=" + state +
+                ", introduction='" + introduction + '\'' +
+                ", maxPeople=" + maxPeople +
+                ", currentPeople=" + currentPeople +
+                ", delete=" + delete +
+                ", deleteReason='" + deleteReason + '\'' +
+                ", viewCount=" + viewCount +
+                ", commentCount=" + commentCount +
+                '}';
     }
 }

--- a/src/main/java/com/matching/project/service/ProjectService.java
+++ b/src/main/java/com/matching/project/service/ProjectService.java
@@ -1,13 +1,15 @@
 package com.matching.project.service;
 
+import com.matching.project.dto.project.LoginProjectSimpleDto;
+import com.matching.project.dto.project.NoneLoginProjectSimpleDto;
 import com.matching.project.dto.project.ProjectRegisterRequestDto;
 import com.matching.project.dto.project.ProjectRegisterResponseDto;
-import com.matching.project.dto.project.ProjectSimpleDto;
 import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ProjectService {
     public ProjectRegisterResponseDto projectRegister(ProjectRegisterRequestDto projectRegisterRequestDto) throws Exception;
 
-    public List<ProjectSimpleDto> projectRecruitingList(Pageable pageable) throws Exception;
+    public List<NoneLoginProjectSimpleDto> NoneLoginProjectRecruitingList(Pageable pageable) throws Exception;
+    public List<LoginProjectSimpleDto> LoginProjectRecruitingList(Pageable pageable) throws Exception;
 }

--- a/src/test/java/com/matching/project/service/ProjectServiceImplTest.java
+++ b/src/test/java/com/matching/project/service/ProjectServiceImplTest.java
@@ -3,19 +3,19 @@ package com.matching.project.service;
 import com.matching.project.dto.enumerate.OAuth;
 import com.matching.project.dto.enumerate.Position;
 import com.matching.project.dto.enumerate.Role;
-import com.matching.project.dto.project.ProjectPositionDto;
-import com.matching.project.dto.project.ProjectRegisterRequestDto;
-import com.matching.project.dto.project.ProjectRegisterResponseDto;
-import com.matching.project.dto.project.ProjectSimpleDto;
+import com.matching.project.dto.project.*;
 import com.matching.project.entity.*;
 import com.matching.project.repository.*;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -131,8 +131,6 @@ class ProjectServiceImplTest {
         given(projectRepository.save(any(Project.class))).willReturn(project);
         given(projectPositionRepository.save(any(ProjectPosition.class))).willReturn(projectPosition1);
         given(projectTechnicalStackRepository.save(any(ProjectTechnicalStack.class))).willReturn(projectTechnicalStack1);
-
-        given(userRepository.findById(any(Long.class))).willReturn(Optional.of(user));
         given(projectUserRepository.save(any(ProjectUser.class))).willReturn(projectUser);
 
         ProjectRegisterResponseDto projectRegisterResponseDto = null;
@@ -145,7 +143,6 @@ class ProjectServiceImplTest {
         }
 
         // then
-        verify(userRepository).findById(any());
         verify(projectRepository).save(any());
         verify(projectPositionRepository).save(any());
         verify(projectTechnicalStackRepository, times(2)).save(any());
@@ -165,11 +162,97 @@ class ProjectServiceImplTest {
     }
 
     @Test
-    public void 프로젝트_모집중_목록_조회_성공_테스트() {
+    public void 비로그인_프로젝트_모집중_목록_조회_성공_테스트() {
         LocalDateTime createDate = LocalDateTime.of(2022, 06, 24, 10, 10, 10);
         LocalDate startDate = LocalDate.of(2022, 06, 24);
         LocalDate endDate = LocalDate.of(2022, 06, 28);
         
+        // 프로젝트 객체
+        Project project1 = Project.builder()
+                .no(1L)
+                .name("testName1")
+                .createUserName("user1")
+                .createDate(createDate)
+                .startDate(startDate)
+                .endDate(endDate)
+                .state(true)
+                .introduction("testIntroduction1")
+                .maxPeople(10)
+                .currentPeople(4)
+                .delete(false)
+                .deleteReason(null)
+                .viewCount(10)
+                .commentCount(10)
+                .image(null)
+                .build();
+
+        Project project2 = Project.builder()
+                .no(2L)
+                .name("testName2")
+                .createUserName("user1")
+                .createDate(createDate)
+                .startDate(startDate)
+                .endDate(endDate)
+                .state(true)
+                .introduction("testIntroduction2")
+                .maxPeople(10)
+                .currentPeople(4)
+                .delete(false)
+                .deleteReason(null)
+                .viewCount(10)
+                .commentCount(10)
+                .image(null)
+                .build();
+
+        List<Project> projectList = new ArrayList<>();
+        projectList.add(project2);
+        projectList.add(project1);
+
+        // List to Page
+        Pageable pageable = PageRequest.of(0, 4, Sort.by("no").descending());
+        int start = (int)pageable.getOffset();
+        int end = (start + pageable.getPageSize()) > projectList.size() ? projectList.size() : (start + pageable.getPageSize());
+        Page<Project> projectPage = new PageImpl<>(projectList.subList(start, end), pageable, projectList.size());
+
+        given(projectRepository.findByStateProjectPage(any(Boolean.class), any(Boolean.class), any(Pageable.class))).willReturn(projectPage);
+
+        List<NoneLoginProjectSimpleDto> projectSimpleDtoList = null;
+
+        try {
+            projectSimpleDtoList = projectService.NoneLoginProjectRecruitingList(pageable);
+        } catch (Exception e) {
+
+        }
+
+        verify(projectRepository, times(1)).findByStateProjectPage(any(Boolean.class), any(Boolean.class), any(Pageable.class));
+
+        assertEquals(projectSimpleDtoList.size(), 2);
+        assertEquals(projectSimpleDtoList.get(0).getNo(), 2L);
+        assertEquals(projectSimpleDtoList.get(0).getName(), "testName2");
+        assertEquals(projectSimpleDtoList.get(0).getProfile(), null);
+        assertEquals(projectSimpleDtoList.get(0).getMaxPeople(), 10);
+        assertEquals(projectSimpleDtoList.get(0).getCurrentPeople(), 4);
+        assertEquals(projectSimpleDtoList.get(0).getViewCount(), 10);
+        assertEquals(projectSimpleDtoList.get(0).getCommentCount(), 10);
+        assertEquals(projectSimpleDtoList.get(0).getRegister(), "user1");
+
+        assertEquals(projectSimpleDtoList.get(1).getNo(), 1L);
+        assertEquals(projectSimpleDtoList.get(1).getName(), "testName1");
+        assertEquals(projectSimpleDtoList.get(1).getProfile(), null);
+        assertEquals(projectSimpleDtoList.get(1).getMaxPeople(), 10);
+        assertEquals(projectSimpleDtoList.get(1).getCurrentPeople(), 4);
+        assertEquals(projectSimpleDtoList.get(1).getViewCount(), 10);
+        assertEquals(projectSimpleDtoList.get(1).getCommentCount(), 10);
+        assertEquals(projectSimpleDtoList.get(1).getRegister(), "user1");
+    }
+
+
+    @Test
+    public void 로그인_프로젝트_모집중_목록_조회_성공_테스트() {
+        LocalDateTime createDate = LocalDateTime.of(2022, 06, 24, 10, 10, 10);
+        LocalDate startDate = LocalDate.of(2022, 06, 24);
+        LocalDate endDate = LocalDate.of(2022, 06, 28);
+
         // 유저 객체
         User user = User.builder()
                 .no(1L)
@@ -185,7 +268,7 @@ class ProjectServiceImplTest {
                 .image(null)
                 .userPosition(null)
                 .build();
-        
+
         // 프로젝트 객체
         Project project1 = Project.builder()
                 .no(1L)
@@ -243,13 +326,19 @@ class ProjectServiceImplTest {
                 .build();
         bookMarkList.add(bookMark);
 
+        UserDetails userDetails = user;
+
+        // 로그인한 유저 securityContext set
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
         given(bookMarkRepository.findByUserNo(any(Long.class))).willReturn(bookMarkList);
         given(projectRepository.findByStateProjectPage(any(Boolean.class), any(Boolean.class), any(Pageable.class))).willReturn(projectPage);
 
-        List<ProjectSimpleDto> projectSimpleDtoList = null;
+        List<LoginProjectSimpleDto> projectSimpleDtoList = null;
 
         try {
-            projectSimpleDtoList = projectService.projectRecruitingList(pageable);
+            projectSimpleDtoList = projectService.LoginProjectRecruitingList(pageable);
         } catch (Exception e) {
 
         }
@@ -261,9 +350,9 @@ class ProjectServiceImplTest {
         assertEquals(projectSimpleDtoList.get(0).getNo(), 2L);
         assertEquals(projectSimpleDtoList.get(0).getName(), "testName2");
         assertEquals(projectSimpleDtoList.get(0).getProfile(), null);
-        assertEquals(projectSimpleDtoList.get(0).isBookmark(), false);
         assertEquals(projectSimpleDtoList.get(0).getMaxPeople(), 10);
         assertEquals(projectSimpleDtoList.get(0).getCurrentPeople(), 4);
+        assertEquals(projectSimpleDtoList.get(0).isBookMark(), false);
         assertEquals(projectSimpleDtoList.get(0).getViewCount(), 10);
         assertEquals(projectSimpleDtoList.get(0).getCommentCount(), 10);
         assertEquals(projectSimpleDtoList.get(0).getRegister(), "user1");
@@ -271,9 +360,9 @@ class ProjectServiceImplTest {
         assertEquals(projectSimpleDtoList.get(1).getNo(), 1L);
         assertEquals(projectSimpleDtoList.get(1).getName(), "testName1");
         assertEquals(projectSimpleDtoList.get(1).getProfile(), null);
-        assertEquals(projectSimpleDtoList.get(1).isBookmark(), true);
         assertEquals(projectSimpleDtoList.get(1).getMaxPeople(), 10);
         assertEquals(projectSimpleDtoList.get(1).getCurrentPeople(), 4);
+        assertEquals(projectSimpleDtoList.get(1).isBookMark(), true);
         assertEquals(projectSimpleDtoList.get(1).getViewCount(), 10);
         assertEquals(projectSimpleDtoList.get(1).getCommentCount(), 10);
         assertEquals(projectSimpleDtoList.get(1).getRegister(), "user1");

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,21 @@ jasypt:
   encryptor:
     password: test
 spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: test
+    password: test
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
   security:
     oauth2:
       client:


### PR DESCRIPTION
jwt 추가로 인한 프로젝트 모집 리스트 조회 기능 변경하였습니다,
1. 변경 도중 로그인한 유저와 비로그인 유저가 사용하는 API가 달라야 되서, 
기존에 있던 프로젝트 모집 리스트 조회 기능을 비로그인 유저가 사용하는 API 와 로그인 유저가 사용하는 API로 분할하였습니다.
2. 이메일 기능 추가로 인하여 통합테스트가 작동되지 않아서 test쪽 application.yml에 관련 코드 추가했습니다.